### PR TITLE
Add high-end fruit store landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>台灣精品水果</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@300;500&family=Montserrat:wght@300;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-content">
+      <h1>台灣精品水果</h1>
+      <p>來自島嶼的甜蜜禮讚</p>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="products">
+      <div class="product-card">
+        <img src="https://images.unsplash.com/photo-1601004890684-d8cbf643f5f2?auto=format&fit=crop&w=800&q=60" alt="愛文芒果" />
+        <h2>愛文芒果</h2>
+        <p>濃郁香氣與絕佳甜度的夏日之王。</p>
+      </div>
+      <div class="product-card">
+        <img src="https://images.unsplash.com/photo-1550258987-190a2d41a8ba?auto=format&fit=crop&w=800&q=60" alt="珍珠芭樂" />
+        <h2>珍珠芭樂</h2>
+        <p>爽脆多汁，清甜無渣。</p>
+      </div>
+      <div class="product-card">
+        <img src="https://images.unsplash.com/photo-1502741338009-cac2772e18bc?auto=format&fit=crop&w=800&q=60" alt="木瓜" />
+        <h2>木瓜</h2>
+        <p>絲滑入口，香氣撲鼻的熟成風味。</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>聯絡我們：<a href="mailto:info@example.com">info@example.com</a></p>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,78 @@
+body {
+  margin: 0;
+  font-family: 'Montserrat', 'Noto Serif JP', serif;
+  background-color: #fafafa;
+  color: #333;
+}
+
+.hero {
+  background-image: url('https://images.unsplash.com/photo-1567306226416-28f0efdc88ce?auto=format&fit=crop&w=1350&q=80');
+  background-size: cover;
+  background-position: center;
+  height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #fff;
+}
+
+.hero-content h1 {
+  font-size: 3rem;
+  margin: 0;
+  font-weight: 500;
+}
+
+.hero-content p {
+  margin-top: 0.5rem;
+  font-size: 1.2rem;
+  font-weight: 300;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.products {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.product-card {
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  transition: transform 0.3s ease;
+}
+
+.product-card:hover {
+  transform: translateY(-5px);
+}
+
+.product-card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.product-card h2 {
+  font-size: 1.5rem;
+  margin: 1rem;
+  font-weight: 500;
+}
+
+.product-card p {
+  margin: 0 1rem 1.5rem;
+  font-weight: 300;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 0;
+  background: #f0f0f0;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- Add Japanese-inspired landing page showcasing premium Taiwanese fruits
- Style page with modern typography, hero banner, product grid, and contact footer

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b2a5193488323b861dd8b7a671bec